### PR TITLE
renamed project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Click here to read the assignment](./docs/assignment.md)
 
-## vanilla
+## clipboard-recruiting-tht-sdet
 
 This is a base starter kit framework that you can use to build your tests for the above assignment.
 However, if you are more comfortable with your own tool kit, feel free to use that as well!

--- a/docs/assignment.md
+++ b/docs/assignment.md
@@ -1,6 +1,6 @@
 # Introduction
 
-SDET or a Engineering Manager in Quality, we are pretty hands on when it comes to Quality.
+SDET or an Engineering Manager in Quality, we are pretty hands on when it comes to Quality.
 
 In the assignment, we are looking to see your design and coding skills to see how well you can take care of Quality;
 within the quality department.
@@ -12,7 +12,7 @@ You can use any automation tool/library of your choice - we like selenium but fe
 
 If you like, we also provide you a base test framework so that you can directly get started writing tests, rather than setting up framework. [This framework]
 
-Note: Base (vanilla) framework is to help you get things faster - “if you want to”. However we realize, sometimes you may like to use your own tool set, in which case you are free to do so - with no marks deducted - so feel free to pickup whatever you like :).
+Note: Base (clipboard-recruiting-tht-sdet) framework is to help you get things faster - “if you want to”. However we realize, sometimes you may like to use your own tool set, in which case you are free to do so - with no marks deducted - so feel free to pickup whatever you like :).
 
 > One request, don’t use any low code or licensed automation tools.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.tester</groupId>
-    <artifactId>vanilla</artifactId>
+    <artifactId>clipboard-recruiting-tht-sdet</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>


### PR DESCRIPTION
Renaming this project on request of Mike Cook ([here](https://clipboardhealth.slack.com/archives/C5FQ8H2G0/p1670345421069199?thread_ts=1670255899.367059&cid=C5FQ8H2G0)), project renamed to `clipboard-recruiting-tht-sdet`.

> Changes locally tested Okay before creating the branch. 

Note: This is due to the reason that we are getting strict on our repo policies and a name like `clipboard-recruiting-tht-sdet` is more in intuitive/obvious for our internal security audit team than Vanilla to decide if they should keep it public or private. 

